### PR TITLE
Work with size types.

### DIFF
--- a/futhark/SIRT.fut
+++ b/futhark/SIRT.fut
@@ -17,12 +17,19 @@ let SIRT [n][p][a](angles : [a]f32)
   let halfsize = size/2
   let numrhos = p/a
   let (steep_lines, flat_lines, proj_division, _) = preprocess angles numrhos
-  let (steep_proj, flat_proj) = fix_projections projections proj_division
+  let (steep_proj, flat_proj) = fix_projections projections (proj_division :> [p]bool)
+  let num_steep = length steep_proj
+  let steep_proj = steep_proj :> [num_steep]f32
+  let num_flat = length flat_proj
+  let flat_proj = flat_proj :> [num_flat]f32
 
   let rowsums_steep = inverse (fp steep_lines rhozero deltarho numrhos halfsize (replicate n 1.0f32))
+                      :> [num_steep]f32
   let rowsums_flat = inverse (fp flat_lines rhozero deltarho numrhos halfsize (replicate n 1.0f32))
+                     :> [num_flat]f32
 
   let inversecolumnsums = inverse (backprojection (replicate (length steep_proj) 1.0f32) (replicate (length flat_proj) 1.0f32) steep_lines flat_lines rhozero deltarho rhosprpixel numrhos halfsize)
+                          :> [n]f32
 
   let res = loop (image) = (image) for iter < iterations do
       let imageT =  if (size < 10000)
@@ -30,11 +37,12 @@ let SIRT [n][p][a](angles : [a]f32)
                      else (replicate n 1.0f32)
       let fp_steep = fp steep_lines rhozero deltarho numrhos halfsize image
       let fp_flat = fp flat_lines rhozero deltarho numrhos halfsize imageT
-      let fp_diff_steep = map2 (-) steep_proj fp_steep
-      let fp_diff_flat = map2 (-) flat_proj fp_flat
+      let fp_diff_steep = map2 (-) steep_proj (fp_steep :> [num_steep]f32)
+      let fp_diff_flat = map2 (-) flat_proj (fp_flat :> [num_flat]f32)
       let fp_weighted_steep = map2 (*) rowsums_steep fp_diff_steep
       let fp_weighted_flat = map2 (*) rowsums_flat fp_diff_flat
       let bp = backprojection fp_weighted_steep fp_weighted_flat steep_lines flat_lines rhozero deltarho rhosprpixel numrhos halfsize
+               :> [n]f32
       let bp_weighted = map2 (*) inversecolumnsums bp
       in image with [0:n] = map2 (+) image bp_weighted
 

--- a/futhark/backprojection_sparse.fut
+++ b/futhark/backprojection_sparse.fut
@@ -33,5 +33,5 @@ let main  [p][a](angles : [a]f32)
           let numrhos = p/a
           let (steep_lines, flat_lines, is_flat, _) = preprocess angles numrhos
 
-	        let (steep_proj, flat_proj) = fix_projections projections is_flat
+	        let (steep_proj, flat_proj) = fix_projections projections (is_flat :> [p]bool)
           in backprojection steep_proj flat_proj steep_lines flat_lines rhozero deltarho rhosprpixel numrhos halfsize

--- a/futhark/sirtlib.fut
+++ b/futhark/sirtlib.fut
@@ -9,7 +9,7 @@ type point  = ( f32, f32 )
       let safe_inverse (value: f32) : f32 =
            if value == 0.0 then 0.0 else 1/value
 
-      let inverse (values: []f32) : []f32 =
+      let inverse [n] (values: [n]f32) : [n]f32 =
            map(\v -> safe_inverse v) values
 
      -- divides data into flat and steep parts
@@ -22,7 +22,7 @@ type point  = ( f32, f32 )
 
      -- reasembles forwardprojection to match input parameter
      let postprocess_fp [p][f][s](projection_indexes: [p]i32) (val_steep: [f]f32) (val_flat: [s]f32): [p]f32 =
-          scatter (replicate (f+s) 0.0f32) projection_indexes (val_steep ++ val_flat)
+          scatter (replicate p 0.0f32) projection_indexes (val_steep ++ val_flat :> [p]f32)
 
      -- divides in flat and steep and transposes lines
      let preprocess [a](angles: [a]f32) (numrhos: i32): ([](f32, f32, f32), [](f32, f32, f32), []bool, []i32) =


### PR DESCRIPTION
I am working on adding size types to Futhark ([documentation](https://futhark.readthedocs.io/en/size-types/language-reference.html#size-types), [some rationale](https://futhark-lang.org/blog/2019-08-03-towards-size-types.html)).  This inevitably means that a lot of existing code will end up being type-incorrect.  I am going around and looking at existing Futhark programs to see what it will take to fix them, and hopefully get information about whether the restrictions are unworkable in practice.

This pull request makes synkrotomo work with size types.  It is also fully compatible with current released Futhark.  Most of the changes are about computing various sizes in advance, so the compiler knows what to expect.